### PR TITLE
Typo: mising -> missing

### DIFF
--- a/src/main/java/org/squiddev/cobalt/compiler/Lex.java
+++ b/src/main/java/org/squiddev/cobalt/compiler/Lex.java
@@ -365,7 +365,7 @@ final class Lex {
 
 	private void readUtf8Esc() throws CompileException, UnwindThrowable {
 		saveAndNext();
-		if (current != '{') throw escapeError("mising '{'");
+		if (current != '{') throw escapeError("missing '{'");
 
 		int i = 4;
 		long codepoint = readHex();


### PR DESCRIPTION
Fixed a typo 
mising should be missing

![image](https://github.com/SquidDev/Cobalt/assets/67484093/dae21fd4-0087-4802-821e-6e6b04ad5c45)
