### PR TITLE
Number fixes

### DIFF
--- a/src/main/java/cc/tweaked/cobalt/internal/string/NumberParser.java
+++ b/src/main/java/cc/tweaked/cobalt/internal/string/NumberParser.java
@@ -71,7 +71,16 @@ public final class NumberParser {
 			}
 
 			if (digit >= base) return Double.NaN;
-			x = x * base + digit;
+
+			if (base == 10) {
+				try {
+					x = Math.addExact(Math.multiplyExact(x, base), digit);
+				} catch (ArithmeticException e) {
+					return Double.NaN;
+				}
+			} else {
+				x = x * base + digit;
+			}
 		}
 		return x;
 	}
@@ -119,7 +128,7 @@ public final class NumberParser {
 	}
 
 	private static double scanHexDouble(byte[] bytes, int index, int end) {
-		long result = 0; // The mantissa
+		double result = 0; // The mantissa
 		int exponent = 0;
 
 		int sigDigits = 0, nonSigDigits = 0; // Number of significant digits and non-significant digits (leading 0s).
@@ -187,6 +196,6 @@ public final class NumberParser {
 			exponent += givenExponent;
 		}
 
-		return Math.scalb((double) result, exponent);
+		return Math.scalb(result, exponent);
 	}
 }

--- a/src/main/java/org/squiddev/cobalt/LuaDouble.java
+++ b/src/main/java/org/squiddev/cobalt/LuaDouble.java
@@ -139,7 +139,7 @@ public final class LuaDouble extends LuaNumber {
 	@Override
 	public LuaString checkLuaString() {
 		long l = (long) v;
-		if (l == v) return ValueFactory.valueOf(Long.toString(l));
+		if (l == v && l != Long.MAX_VALUE) return ValueFactory.valueOf(Long.toString(l));
 		if (Double.isNaN(v)) return STR_NAN;
 		if (Double.isInfinite(v)) return v < 0 ? STR_NEGINF : STR_POSINF;
 

--- a/src/test/resources/spec/base_spec.lua
+++ b/src/test/resources/spec/base_spec.lua
@@ -65,6 +65,10 @@ describe("The base library", function()
 				expect('' .. 12):eq('12') expect(12.0 .. ''):eq('12')
 				expect(tostring(-1203 + 0.0)):eq("-1203")
 			end)
+
+			it("correctly handles 2^63", function()
+				expect(tostring(math.floor(2^63))):not_equals("9223372036854775807")
+			end)
 		end)
 
 		it("tables", function() expect(tostring {}):str_match('^table:') end)

--- a/src/test/resources/spec/parser_spec.lua
+++ b/src/test/resources/spec/parser_spec.lua
@@ -1,6 +1,14 @@
 describe("The Lua lexer/parser", function()
 	describe("numbers", function()
 		local load = loadstring or load
+		it("only wraps around hexadecimal numerals with neither an exponent nor radix point", function()
+			-- See https://github.com/cc-tweaked/Cobalt/issues/88
+			expect(tonumber(("9"):rep(19))):eq(1e19)
+			expect(tonumber("0xffffffffffffffff")):eq(-1)
+			expect(tonumber("0xffffffffffffffff.0")):eq(2^64)
+			expect(tonumber("0xffffffffffffffffp0")):eq(2^64)
+		end)
+
 		it("rejects numbers ending in 'f' or 'd'", function()
 			-- Java's Double.parseDouble accepts "2f" and "2d" as a valid number. Make sure we don't.
 			-- See https://github.com/SquidDev/Cobalt/issues/71


### PR DESCRIPTION
Fixes #88. I decided to keep the Lua 5.3 behavior that hexadecimal numbers without a radix point or exponent wrap-around (which was already the current Cobalt behavior) so that it wouldn't need to be changed again whenever Cobalt updates to Lua 5.3. 
Also fixes another bug I found where 2^63 had its last digit incorrectly displaying as 7 instead of 8. This was happening because `Math.pow(2, 63) == (long)Math.pow(2, 63)`: the `long` was getting converted to a `double` in the comparison here, making both equal, even though `(long)Math.pow(2, 63)` is 9223372036854775807 and `Math.pow(2, 63)` is 9223372036854775808.