### PR TITLE
Support throwing UnwindThrowable in created LibFunction functions

### DIFF
--- a/src/main/java/org/squiddev/cobalt/function/LibFunction.java
+++ b/src/main/java/org/squiddev/cobalt/function/LibFunction.java
@@ -284,7 +284,7 @@ public sealed abstract class LibFunction extends LuaFunction
 	public static LibFunction createV(ManyArgs fn) {
 		return new VarArgFunction() {
 			@Override
-			protected Varargs invoke(LuaState state, Varargs args) throws LuaError {
+			protected Varargs invoke(LuaState state, Varargs args) throws LuaError, UnwindThrowable {
 				return fn.invoke(state, args);
 			}
 		};
@@ -305,23 +305,23 @@ public sealed abstract class LibFunction extends LuaFunction
 	}
 
 	public interface ZeroArg {
-		LuaValue call(LuaState state) throws LuaError;
+		LuaValue call(LuaState state) throws LuaError, UnwindThrowable;
 	}
 
 	public interface OneArg {
-		LuaValue call(LuaState state, LuaValue arg) throws LuaError;
+		LuaValue call(LuaState state, LuaValue arg) throws LuaError, UnwindThrowable;
 	}
 
 	public interface TwoArg {
-		LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError;
+		LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError, UnwindThrowable;
 	}
 
 	public interface ThreeArg {
-		LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError;
+		LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError, UnwindThrowable;
 	}
 
 	public interface ManyArgs {
-		Varargs invoke(LuaState state, Varargs args) throws LuaError;
+		Varargs invoke(LuaState state, Varargs args) throws LuaError, UnwindThrowable;
 	}
 
 	/**

--- a/src/main/java/org/squiddev/cobalt/function/OneArgFunction.java
+++ b/src/main/java/org/squiddev/cobalt/function/OneArgFunction.java
@@ -38,22 +38,22 @@ final class OneArgFunction extends LibFunction {
 	}
 
 	@Override
-	protected LuaValue call(LuaState state) throws LuaError {
+	protected LuaValue call(LuaState state) throws LuaError, UnwindThrowable {
 		return function.call(state, Constants.NIL);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg) throws LuaError, UnwindThrowable {
 		return function.call(state, arg);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError, UnwindThrowable {
 		return function.call(state, arg1);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError, UnwindThrowable {
 		return function.call(state, arg1);
 	}
 

--- a/src/main/java/org/squiddev/cobalt/function/ThreeArgFunction.java
+++ b/src/main/java/org/squiddev/cobalt/function/ThreeArgFunction.java
@@ -40,22 +40,22 @@ final class ThreeArgFunction extends LibFunction {
 	}
 
 	@Override
-	protected LuaValue call(LuaState state) throws LuaError {
+	protected LuaValue call(LuaState state) throws LuaError, UnwindThrowable {
 		return function.call(state, NIL, NIL, NIL);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg) throws LuaError, UnwindThrowable {
 		return function.call(state, arg, NIL, NIL);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError, UnwindThrowable {
 		return function.call(state, arg1, arg2, NIL);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError, UnwindThrowable {
 		return function.call(state, arg1, arg2, arg3);
 	}
 

--- a/src/main/java/org/squiddev/cobalt/function/TwoArgFunction.java
+++ b/src/main/java/org/squiddev/cobalt/function/TwoArgFunction.java
@@ -40,22 +40,22 @@ final class TwoArgFunction extends LibFunction {
 	}
 
 	@Override
-	protected LuaValue call(LuaState state) throws LuaError {
+	protected LuaValue call(LuaState state) throws LuaError, UnwindThrowable {
 		return function.call(state, NIL, NIL);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg) throws LuaError, UnwindThrowable {
 		return function.call(state, arg, NIL);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError, UnwindThrowable {
 		return function.call(state, arg1, arg2);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError, UnwindThrowable {
 		return function.call(state, arg1, arg2);
 	}
 

--- a/src/main/java/org/squiddev/cobalt/function/ZeroArgFunction.java
+++ b/src/main/java/org/squiddev/cobalt/function/ZeroArgFunction.java
@@ -38,22 +38,22 @@ final class ZeroArgFunction extends LibFunction {
 	}
 
 	@Override
-	protected LuaValue call(LuaState state) throws LuaError {
+	protected LuaValue call(LuaState state) throws LuaError, UnwindThrowable {
 		return function.call(state);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg) throws LuaError, UnwindThrowable {
 		return function.call(state);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2) throws LuaError, UnwindThrowable {
 		return function.call(state);
 	}
 
 	@Override
-	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError {
+	protected LuaValue call(LuaState state, LuaValue arg1, LuaValue arg2, LuaValue arg3) throws LuaError, UnwindThrowable {
 		return function.call(state);
 	}
 


### PR DESCRIPTION
Correct me if I'm wrong but I don't think there should be any undesirable effects from doing this? It seemed to me like the LibFunction.create parameters were just overlooked when `UnwindThrowable` was implemented.